### PR TITLE
CSUB-1174: Update action to Node.js 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,5 +19,5 @@ inputs:
     default: false
 
 runs:
-  using: 'node12'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/ https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/